### PR TITLE
docs: dev環境バッチスケジュール仕様を更新 (#24)

### DIFF
--- a/specs/050.batch/batch-spec.md
+++ b/specs/050.batch/batch-spec.md
@@ -111,7 +111,7 @@ Lambda（stock-price-batch）× 1本
 | Lambdaリソース | **1セットのみ**（3環境分は作らない） |
 | 送り先バックエンドURL | 環境変数 `BACKEND_API_URL` で切り替え |
 | NAT Gateway | **不要**（Lambda を VPC 外に配置） |
-| EventBridgeスケジュール | **prodのみ有効**（dev・stgは手動実行） |
+| EventBridgeスケジュール | **prod**: 各バッチ個別スケジュール / **dev**: 全バッチ平日17:00 JST一括実行 |
 
 ### Lambda関数一覧
 


### PR DESCRIPTION
## 変更内容

`specs/050.batch/batch-spec.md` のEventBridgeスケジュール方針を更新。

| 変更前 | 変更後 |
|---|---|
| prodのみ有効（dev・stgは手動実行） | prod: 各バッチ個別スケジュール / dev: 全バッチ平日17:00 JST一括実行 |

関連PR: satouhiroyuki/Morincum-batch#71

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)